### PR TITLE
fix: COC v2.1, README headings, build Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,45 +1,20 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-    environment: test
-    env:
-      TRELLO_APIKEY: ${{secrets.TRELLO_APIKEY}}
-      TRELLO_USERTOKEN: ${{secrets.TRELLO_USERTOKEN}}
-      
-    timeout-minutes: 6
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [lts/*, 17.x, 16.x]
-
-    runs-on: ${{ matrix.os }} 
-        
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-      # manually install peerdeps for node 12,14
-    - run: npm i seneca seneca-entity seneca-promisify @seneca/provider @seneca/env
-    - run: npm run build --if-present
-    - run: npm test
-
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./coverage/lcov.info
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -12,6 +12,45 @@
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
+## Quick Example
+
+
+```js
+
+// Setup - get the key value (<SECRET>) separately from a vault or
+// environment variable.
+Seneca()
+  // Get API keys using the seneca-env plugin
+  .use('env', {
+    var: {
+      $TANGOCARD_APIKEY: String,
+      $TANGOCARD_USERTOKEN: String,
+    }
+  })
+  .use('provider', {
+    provider: {
+      tangocard: {
+        keys: {
+          apikey: { value: '$TANGOCARD_APIKEY' },
+          usertoken: { value: '$TANGOCARD_USERTOKEN' },
+        }
+      }
+    }
+  })
+  .use('tangocard-provider')
+
+let board = await seneca.entity('provider/tangocard/board')
+  .load$('<tangocard-board-id>')
+
+Console.log('BOARD', board)
+
+board.desc = 'New description'
+board = await board.save$()
+
+Console.log('UPDATED BOARD', board)
+
+```
+
 ## Install
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -12,44 +12,15 @@
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
-## Quick Example
 
+Provides access to the Tangocard API using the Seneca *provider*
+convention. Tangocard API entities are represented as Seneca entities so
+that they can be accessed using the Seneca entity API and messages.
+See [seneca-entity](senecajs/seneca-entity) and the [Seneca Data
+Entities
+Tutorial](https://senecajs.org/docs/tutorials/understanding-data-entities.html) for more details on the Seneca entity API.
+NOTE: underlying third party SDK needs to be replaced as out of date and has a security issue.
 
-```js
-
-// Setup - get the key value (<SECRET>) separately from a vault or
-// environment variable.
-Seneca()
-  // Get API keys using the seneca-env plugin
-  .use('env', {
-    var: {
-      $TANGOCARD_APIKEY: String,
-      $TANGOCARD_USERTOKEN: String,
-    }
-  })
-  .use('provider', {
-    provider: {
-      tangocard: {
-        keys: {
-          apikey: { value: '$TANGOCARD_APIKEY' },
-          usertoken: { value: '$TANGOCARD_USERTOKEN' },
-        }
-      }
-    }
-  })
-  .use('tangocard-provider')
-
-let board = await seneca.entity('provider/tangocard/board')
-  .load$('<tangocard-board-id>')
-
-Console.log('BOARD', board)
-
-board.desc = 'New description'
-board = await board.save$()
-
-Console.log('UPDATED BOARD', board)
-
-```
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,28 @@
-![Seneca Tangocard-Provider](http://senecajs.org/files/assets/seneca-logo.png)
+![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js](http://senecajs.org) plugin
 
-> _Seneca Tangocard-Provider_ is a plugin for [Seneca](http://senecajs.org)
-
-
-Provides access to the Tangocard API using the Seneca *provider*
-convention. Tangocard API entities are represented as Seneca entities so
-that they can be accessed using the Seneca entity API and messages.
-
-See [seneca-entity](senecajs/seneca-entity) and the [Seneca Data
-Entities
-Tutorial](https://senecajs.org/docs/tutorials/understanding-data-entities.html) for more details on the Seneca entity API.
-
-NOTE: underlying third party SDK needs to be replaced as out of date and has a security issue.
+# @seneca/tangocard-provider
 
 [![npm version](https://img.shields.io/npm/v/@seneca/tangocard-provider.svg)](https://npmjs.com/package/@seneca/tangocard-provider)
 [![build](https://github.com/senecajs/seneca-tangocard-provider/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-tangocard-provider/actions/workflows/build.yml)
-[![Coverage Status](https://coveralls.io/repos/github/senecajs/seneca-tangocard-provider/badge.svg?branch=main)](https://coveralls.io/github/senecajs/seneca-tangocard-provider?branch=main)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-tangocard-provider/badge.svg)](https://snyk.io/test/github/senecajs/seneca-tangocard-provider)
-[![DeepScan grade](https://deepscan.io/api/teams/5016/projects/19462/branches/505954/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5016&pid=19462&bid=505954)
+[![Coverage Status](https://coveralls.io/repos/github/senecajs/seneca-tangocard-provider/badge.svg?branch=main)](https://coveralls.io/github/senecajs/seneca-tangocard-provider?branch=main)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f76e83896b731bb5d609/maintainability)](https://codeclimate.com/github/senecajs/seneca-tangocard-provider/maintainability)
-
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
 
+## Install
+
+```sh
+$ npm install @seneca/tangocard-provider @seneca/env
+```
+
+
+
+<!--START:options-->
 
 ## Quick Example
-
 
 ```js
 
@@ -64,18 +60,25 @@ Console.log('UPDATED BOARD', board)
 
 ```
 
-## Install
+## More Examples
 
-```sh
-$ npm install @seneca/tangocard-provider @seneca/env
-```
+See [test/](test/) for more usage examples.
 
+## Motivation
 
+A [Seneca.js](http://senecajs.org) plugin.
 
-<!--START:options-->
+## Support
 
+If you're using this module and need help, you can:
 
-## Options
+- Post a [github issue](https://github.com/senecajs/seneca-tangocard-provider/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
+
+## API
+
+### Options
 
 * `debug` : boolean <i><small>false</small></i>
 
@@ -99,8 +102,7 @@ seneca.use('TangocardProvider', { name: value, ... })
 
 <!--START:action-list-->
 
-
-## Action Patterns
+### Action Patterns
 
 * [role:entity,base:tangocard,cmd:load,name:repo,zone:provider](#-roleentitybasetangocardcmdloadnamerepozoneprovider-)
 * [role:entity,base:tangocard,cmd:save,name:repo,zone:provider](#-roleentitybasetangocardcmdsavenamerepozoneprovider-)
@@ -111,8 +113,7 @@ seneca.use('TangocardProvider', { name: value, ... })
 
 <!--START:action-desc-->
 
-
-## Action Descriptions
+### Action Descriptions
 
 ### &laquo; `role:entity,base:tangocard,cmd:load,name:repo,zone:provider` &raquo;
 
@@ -138,3 +139,17 @@ Get information about the provider.
 
 
 <!--END:action-desc-->
+
+## Contributing
+
+The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+### Running tests
+
+```sh
+npm run test
+```
+
+## Background
+
+Part of the [Senecajs org](https://github.com/senecajs/).


### PR DESCRIPTION
## What changed
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Added plugin intro description
- Added `package-lock.json` to `.gitignore`
- Updated `build.yml` to Node 24 / ubuntu-latest
- Added npm, build and Snyk badges

## Fixes
- `version_codeconduct`, `readme_headings`, `content_readme`, `content_gitignore`
